### PR TITLE
Add predeploy check and client directives

### DIFF
--- a/admybrand-ai-suite/package.json
+++ b/admybrand-ai-suite/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "predeploy-check": "node predeploy-check.js"
   },
   "dependencies": {
     "framer-motion": "^12.23.12",

--- a/admybrand-ai-suite/predeploy-check.js
+++ b/admybrand-ai-suite/predeploy-check.js
@@ -1,0 +1,47 @@
+const { execSync } = require('child_process');
+
+function run(cmd) {
+  console.log(`\n$ ${cmd}`);
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+try {
+  run('npx next lint');
+  run('npx tsc --noEmit');
+
+  const { readdirSync, readFileSync } = require('fs');
+  const { join } = require('path');
+
+  function getFiles(dir) {
+    let files = [];
+    for (const file of readdirSync(dir, { withFileTypes: true })) {
+      if (file.isDirectory()) {
+        files = files.concat(getFiles(join(dir, file.name)));
+      } else if (file.name.endsWith('.tsx')) {
+        files.push(join(dir, file.name));
+      }
+    }
+    return files;
+  }
+
+  const patterns = [/framer-motion/, /useEffect/, /useState/, /window\./, /document\./];
+  const missing = [];
+
+  for (const file of getFiles(join(__dirname, 'src'))) {
+    const text = readFileSync(file, 'utf8');
+    if (patterns.some((p) => p.test(text))) {
+      if (!/^\s*("use client"|'use client');/m.test(text)) {
+        missing.push(file.replace(__dirname + '/', ''));
+      }
+    }
+  }
+
+  if (missing.length) {
+    console.warn('\nMissing "use client" directive in:\n' + missing.join('\n'));
+  }
+
+  run('npx next build');
+} catch (err) {
+  console.error('Predeploy check failed');
+  process.exit(1);
+}

--- a/admybrand-ai-suite/src/components/Button.tsx
+++ b/admybrand-ai-suite/src/components/Button.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/admybrand-ai-suite/src/components/Card.tsx
+++ b/admybrand-ai-suite/src/components/Card.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 
 export type CardProps = React.HTMLAttributes<HTMLDivElement>;

--- a/admybrand-ai-suite/src/components/FAQItem.tsx
+++ b/admybrand-ai-suite/src/components/FAQItem.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState } from "react";
 
 export interface FAQItemProps {

--- a/admybrand-ai-suite/src/components/FeatureCard.tsx
+++ b/admybrand-ai-suite/src/components/FeatureCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import { motion } from "framer-motion";
 

--- a/admybrand-ai-suite/src/components/Hero.tsx
+++ b/admybrand-ai-suite/src/components/Hero.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import { motion } from "framer-motion";
 import Button from "./Button";

--- a/admybrand-ai-suite/src/components/Modal.tsx
+++ b/admybrand-ai-suite/src/components/Modal.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import Button from "./Button";
 

--- a/admybrand-ai-suite/src/components/PricingCard.tsx
+++ b/admybrand-ai-suite/src/components/PricingCard.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import Button from "./Button";
 

--- a/admybrand-ai-suite/src/components/TestimonialCarousel.tsx
+++ b/admybrand-ai-suite/src/components/TestimonialCarousel.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState } from "react";
 
 export interface Testimonial {


### PR DESCRIPTION
## Summary
- add `"use client"` to interactive components
- introduce a `predeploy-check.js` script to lint, typecheck, ensure client components, and test build
- expose `predeploy-check` in package.json scripts

## Testing
- `node predeploy-check.js`

------
https://chatgpt.com/codex/tasks/task_e_688ba617095c8324b3b602e42c76e33d