### PR TITLE
Remove external font causing HTTP 418 build error

### DIFF
--- a/admybrand-ai-suite/src/app/globals.css
+++ b/admybrand-ai-suite/src/app/globals.css
@@ -22,7 +22,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-inter), sans-serif;
+  font-family: sans-serif;
 }
 
 html {

--- a/admybrand-ai-suite/src/app/layout.tsx
+++ b/admybrand-ai-suite/src/app/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,10 +12,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={inter.variable}>
-      <body className={`antialiased ${inter.className}`}>
-        {children}
-      </body>
+    <html lang="en">
+      <body className="antialiased">{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- drop `next/font/google` usage to avoid remote font fetching
- simplify global styles to use default sans-serif font

## Testing
- `npm run lint`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d0047e9c88324a3979d172c96f258